### PR TITLE
Underscore implementation bugfix

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,11 @@
 
 All Notable changes to `spatie/string` will be documented in this file
 
+## 1.8.1 - 2015-06-12
+
+### Bugfix
+- Fixed underscore methods that use the string as a parameter
+
 ## 1.8.0 - 2015-06-12
 
 ### Added

--- a/src/Integrations/Underscore.php
+++ b/src/Integrations/Underscore.php
@@ -52,7 +52,7 @@ class Underscore
     public function call($string, $method, $args)
     {
         if ($this->methodUsesStringAsFirstArgument($method)) {
-            $args = [(string) $string] + $args;
+            array_unshift($args, (string) $string);
         }
 
         $underscoreResult = call_user_func_array(['Underscore\Types\Strings', $method], $args);

--- a/tests/Integrations/UnderscoreTest.php
+++ b/tests/Integrations/UnderscoreTest.php
@@ -15,6 +15,14 @@ class UnderscoreTest extends \PHPUnit_Framework_TestCase
     /**
      * @test
      */
+    public function it_can_use_underscore_methods_that_have_a_string_as_input()
+    {
+        $this->assertEquals('tobeornottobe', (string) string('tobe')->append('ornottobe'));
+    }
+
+    /**
+     * @test
+     */
     public function it_can_use_underscore_methods_that_do_not_need_a_string_as_input()
     {
         $this->assertEquals(20, strlen((string) string()->random(20)));


### PR DESCRIPTION
Using the plus operator would replace the string with the first argument since they both have a `0` key.
