### PR TITLE
Add edge case to correct possessive of 'it'

### DIFF
--- a/src/Str.php
+++ b/src/Str.php
@@ -281,7 +281,7 @@ class Str implements ArrayAccess
         if ($this->string == '') {
             return new static();
         }
-        
+
         $noApostropheEdgeCases = ['it'];
 
         if (in_array($this->string, $noApostropheEdgeCases)) {

--- a/src/Str.php
+++ b/src/Str.php
@@ -281,6 +281,12 @@ class Str implements ArrayAccess
         if ($this->string == '') {
             return new static();
         }
+        
+        $noApostropheEdgeCases = ['it'];
+
+        if (in_array($this->string, $noApostropheEdgeCases)) {
+            return new static($this->string.'s');
+        }
 
         return new static($this->string.'\''.($this->string[strlen($this->string) - 1] != 's' ? 's' : ''));
     }

--- a/tests/Functions/PossessiveTest.php
+++ b/tests/Functions/PossessiveTest.php
@@ -22,4 +22,10 @@ class PossessiveTest extends \PHPUnit_Framework_TestCase
     {
         $this->assertInstanceOf(\Spatie\String\Str::class, string('Bob')->possessive());
     }
+
+    /** @test */
+    public function it_can_handle_its_edge_case()
+    {
+        $this->assertEquals('its', (string) string('it')->possessive());
+    }
 }


### PR DESCRIPTION
Currently, `string('it')->possessive()` returns 'it's' which is a contraction of 'it is'. It should return the possessive 'its'. 

This PR fixes this in the `possessive()` method and provides a unit test in the `PossessiveTest` class.