### PR TITLE
Use PHPUnit\Framework\TestCase instead of PHPUnit_Framework_TestCase

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -20,7 +20,7 @@ before_script:
   - travis_retry composer update ${COMPOSER_FLAGS} --no-interaction --prefer-dist
 
 script:
-  - phpunit --coverage-text --coverage-clover=coverage.clover
+  - vendor/bin/phpunit --coverage-text --coverage-clover=coverage.clover
 
 after_script:
   - php vendor/bin/ocular code-coverage:upload --format=php-clover coverage.clover

--- a/composer.json
+++ b/composer.json
@@ -22,7 +22,7 @@
     "anahkiasen/underscore-php": "^2.0"
   },
   "require-dev": {
-    "phpunit/phpunit" : "5.*",
+    "phpunit/phpunit" : "^5.7",
     "scrutinizer/ocular": "~1.1"
   },
   "autoload": {

--- a/tests/Functions/BetweenTest.php
+++ b/tests/Functions/BetweenTest.php
@@ -2,7 +2,9 @@
 
 namespace Spatie\String\Test\Functions;
 
-class BetweenTest extends \PHPUnit_Framework_TestCase
+use PHPUnit\Framework\TestCase;
+
+class BetweenTest extends TestCase
 {
     /** @test */
     public function it_can_return_the_string_between_two_string()

--- a/tests/Functions/ConcatTest.php
+++ b/tests/Functions/ConcatTest.php
@@ -2,7 +2,9 @@
 
 namespace Spatie\String\Test\Functions;
 
-class ConcatTest extends \PHPUnit_Framework_TestCase
+use PHPUnit\Framework\TestCase;
+
+class ConcatTest extends TestCase
 {
     /** @test */
     public function it_can_concatenate_a_string()

--- a/tests/Functions/ContainsTest.php
+++ b/tests/Functions/ContainsTest.php
@@ -2,7 +2,9 @@
 
 namespace Spatie\String\Test\Functions;
 
-class ContainsTest extends \PHPUnit_Framework_TestCase
+use PHPUnit\Framework\TestCase;
+
+class ContainsTest extends TestCase
 {
     /** @test */
     public function it_is_an_alias_for_find()

--- a/tests/Functions/PossessiveTest.php
+++ b/tests/Functions/PossessiveTest.php
@@ -2,7 +2,9 @@
 
 namespace Spatie\String\Test\Functions;
 
-class PossessiveTest extends \PHPUnit_Framework_TestCase
+use PHPUnit\Framework\TestCase;
+
+class PossessiveTest extends TestCase
 {
     /** @test */
     public function it_can_create_the_possessive_version_of_a_string()

--- a/tests/Functions/PrefixTest.php
+++ b/tests/Functions/PrefixTest.php
@@ -2,7 +2,9 @@
 
 namespace Spatie\String\Test\Functions;
 
-class PrefixTest extends \PHPUnit_Framework_TestCase
+use PHPUnit\Framework\TestCase;
+
+class PrefixTest extends TestCase
 {
     /** @test */
     public function it_can_prefix_a_string()

--- a/tests/Functions/ReplaceFirstTest.php
+++ b/tests/Functions/ReplaceFirstTest.php
@@ -2,7 +2,9 @@
 
 namespace Spatie\String\Test\Functions;
 
-class ReplaceFirstTest extends \PHPUnit_Framework_TestCase
+use PHPUnit\Framework\TestCase;
+
+class ReplaceFirstTest extends TestCase
 {
     /** @test */
     public function it_replaces_the_first_occurence_of_a_string_by_another_string()

--- a/tests/Functions/ReplaceLastTest.php
+++ b/tests/Functions/ReplaceLastTest.php
@@ -2,7 +2,9 @@
 
 namespace Spatie\String\Test\Functions;
 
-class ReplaceLastTest extends \PHPUnit_Framework_TestCase
+use PHPUnit\Framework\TestCase;
+
+class ReplaceLastTest extends TestCase
 {
     /** @test */
     public function it_replaces_the_last_occurence_of_a_string_by_another_string()

--- a/tests/Functions/SegmentTest.php
+++ b/tests/Functions/SegmentTest.php
@@ -2,7 +2,9 @@
 
 namespace Spatie\String\Test\Functions;
 
-class SegmentTest extends \PHPUnit_Framework_TestCase
+use PHPUnit\Framework\TestCase;
+
+class SegmentTest extends TestCase
 {
     /** @test */
     public function it_retrieves_a_segment()

--- a/tests/Functions/SuffixTest.php
+++ b/tests/Functions/SuffixTest.php
@@ -2,7 +2,9 @@
 
 namespace Spatie\String\Test\Functions;
 
-class SuffixTest extends \PHPUnit_Framework_TestCase
+use PHPUnit\Framework\TestCase;
+
+class SuffixTest extends TestCase
 {
     /** @test */
     public function it_can_suffix_a_string()

--- a/tests/Functions/TeaseTest.php
+++ b/tests/Functions/TeaseTest.php
@@ -2,7 +2,9 @@
 
 namespace Spatie\String\Test\Functions;
 
-class TeaseTest extends \PHPUnit_Framework_TestCase
+use PHPUnit\Framework\TestCase;
+
+class TeaseTest extends TestCase
 {
     protected $longText = 'Now that there is the Tec-9, a crappy spray gun from South Miami. This gun is advertised as the most popular gun in American crime. Do you believe that shit? It actually says that in the little book that comes with it: the most popular gun in American crime.';
 

--- a/tests/Functions/ToLowerTest.php
+++ b/tests/Functions/ToLowerTest.php
@@ -2,7 +2,9 @@
 
 namespace Spatie\String\Test\Functions;
 
-class ToLowerTest extends \PHPUnit_Framework_TestCase
+use PHPUnit\Framework\TestCase;
+
+class ToLowerTest extends TestCase
 {
     /** @test */
     public function it_can_convert_a_string_to_lowercase()

--- a/tests/Functions/ToUpperTest.php
+++ b/tests/Functions/ToUpperTest.php
@@ -2,7 +2,9 @@
 
 namespace Spatie\String\Test\Functions;
 
-class ToUpperTest extends \PHPUnit_Framework_TestCase
+use PHPUnit\Framework\TestCase;
+
+class ToUpperTest extends TestCase
 {
     /** @test */
     public function it_can_convert_a_string_to_uppercase()

--- a/tests/Functions/TrimTest.php
+++ b/tests/Functions/TrimTest.php
@@ -2,7 +2,9 @@
 
 namespace Spatie\String\Test\Functions;
 
-class TrimTest extends \PHPUnit_Framework_TestCase
+use PHPUnit\Framework\TestCase;
+
+class TrimTest extends TestCase
 {
     /** @test */
     public function it_trims_default_characters()

--- a/tests/Integrations/UnderscoreTest.php
+++ b/tests/Integrations/UnderscoreTest.php
@@ -2,7 +2,9 @@
 
 namespace Spatie\String\Test\Integrations;
 
-class UnderscoreTest extends \PHPUnit_Framework_TestCase
+use PHPUnit\Framework\TestCase;
+
+class UnderscoreTest extends TestCase
 {
     /** @test */
     public function it_can_use_underscores_methods()

--- a/tests/StringTest.php
+++ b/tests/StringTest.php
@@ -2,9 +2,10 @@
 
 namespace Spatie\String\Test;
 
+use PHPUnit\Framework\TestCase;
 use Spatie\String\Exceptions\ErrorCreatingStringException;
 
-class StringTest extends \PHPUnit_Framework_TestCase
+class StringTest extends TestCase
 {
     /** @test */
     public function the_string_function_returns_a_string_instance()


### PR DESCRIPTION
I use the `PHPUnit\Framework\TestCase` notation instead of `PHPUnit_Framework_TestCase` while extending our TestCases. This will help us migrate to PHPUnit 6, that [no longer support snake case class names](https://github.com/sebastianbergmann/phpunit/blob/master/ChangeLog-6.0.md#changed-1).

Just need to bump PHPUnit version to [`^5.7`](https://github.com/sebastianbergmann/phpunit/blob/master/ChangeLog-5.7.md) for compatibility.

Also updated `Travis CI` to use the installed `PHPUnit`, not the global one.