### PR TITLE
Drop php-5.6 because it will be end of life

### DIFF
--- a/.styleci.yml
+++ b/.styleci.yml
@@ -1,3 +1,1 @@
 preset: laravel
-
-linting: true

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,7 +1,6 @@
 language: php
 
 php:
-  - 5.6
   - 7.0
   - 7.1
   - 7.2

--- a/composer.json
+++ b/composer.json
@@ -18,11 +18,11 @@
     }
   ],
   "require": {
-    "php" : ">=5.6.0",
+    "php" : ">=7.0",
     "anahkiasen/underscore-php": "^2.0"
   },
   "require-dev": {
-    "phpunit/phpunit" : "^5.7",
+    "phpunit/phpunit" : "^6.5",
     "scrutinizer/ocular": "~1.1"
   },
   "autoload": {

--- a/tests/StringTest.php
+++ b/tests/StringTest.php
@@ -28,7 +28,7 @@ class StringTest extends TestCase
     /** @test */
     public function it_doesnt_accept_arrays()
     {
-        $this->setExpectedException(ErrorCreatingStringException::class);
+        $this->expectException(ErrorCreatingStringException::class);
 
         string(['foo', 'bar', 'baz']);
     }
@@ -36,7 +36,7 @@ class StringTest extends TestCase
     /** @test */
     public function it_doesnt_accept_empty_arrays()
     {
-        $this->setExpectedException(ErrorCreatingStringException::class);
+        $this->expectException(ErrorCreatingStringException::class);
 
         string([]);
     }
@@ -44,7 +44,7 @@ class StringTest extends TestCase
     /** @test */
     public function it_doesnt_accept_objects_that_dont_implement_tostring()
     {
-        $this->setExpectedException(ErrorCreatingStringException::class);
+        $this->expectException(ErrorCreatingStringException::class);
 
         string(new \StdClass());
     }
@@ -76,7 +76,7 @@ class StringTest extends TestCase
     /** @test */
     public function it_raises_an_exception_when_an_undefined_method_is_called()
     {
-        $this->setExpectedException('Spatie\String\Exceptions\UnknownFunctionException');
+        $this->expectException('Spatie\String\Exceptions\UnknownFunctionException');
 
         string('test')->unknownFunction('hi');
     }
@@ -122,7 +122,7 @@ class StringTest extends TestCase
     public function it_raises_an_exception_when_trying_to_unset_via_an_offset()
     {
         $string = string('string');
-        $this->setExpectedException('Spatie\String\Exceptions\UnsetOffsetException');
+        $this->expectException('Spatie\String\Exceptions\UnsetOffsetException');
         unset($string[0]);
     }
 }


### PR DESCRIPTION
# Changed log

- According to this [post](https://haydenjames.io/php-5-6-eol-end-of-life-php-7-compatibility-check/), the ```php-56``` will be end of life soon.
It's time to update the PHPUnit version and drop the ```php-56``` support.
- I use the ```expectException``` to replace the ```setExpectedException``` because the PHPUnit ```6.0+``` will not support the ```setExpectedException``` method.
- Remove the ```linting``` setting from ```styleci.yml```.